### PR TITLE
Add event for term manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## Unreleased
+### Added
+- Add new event for collect and manipulate facet terms (see FilterEvent.php) @chowanski
+- New interface for term manipulation: _TermNormalizerInterface_ @chowanski
+- Detailed configuration (service id, cache id, cache time, state) for enum term normalization @chowanski
+- Detailed configuration (service id, cache id, cache time, state) for category term normalization @chowanski
+
 ### Changed
 - Sorting query can be null for "no-sorting" / "relevance sorting" @chowanski
+
+### Deprecated
+- Global cache time from config (can now defined for each service separate) @chowanski
 
 ## [6.0.0] - 2017-09-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ best_it_commercetools_filter:
     url_generator_id:     best_it_commercetools_filter.generator.default_filter_url_generator
 
     # Cache life time. Enum Attribute labels are cached to minimize CommerceTools requests.
+    # DEPRECATED: Do not use. Switch to enum_normalizer
     cache_life_time:      86400
  
     # Sorting. At least one sorting options must exist
@@ -164,6 +165,40 @@ best_it_commercetools_filter:
                    
         # Mark matching variants with "isMatchingVariant". (default: false)
         match_variants:       true
+        
+    # Enum Normalizer
+    # CommerceTools only returns enum keys. We have to normalize it.
+    # This bundle ships one standard way - but you can define your own normalizer as well
+    enum_normalizer:
+    
+        # Switch this normalizer on / off (default: true)
+        enable: false
+        
+        # You can define your own normalizer service (default: see id below)
+        normalizer_id: best_it_commercetools_filter.normalizer_term.enum_attribute_normalizer
+        
+        # You can define your own cache pool (default: see id below)
+        cache_id: cache.app
+        
+        # Time in seconds (default: 86400)
+        cache_life_time: 60
+        
+    # Category Normalizer
+    # CommerceTools only returns category id's. We have to normalize it.
+    # This bundle ships one standard way - but you can define your own normalizer as well
+    category_normalizer:
+    
+        # Switch this normalizer on / off (default: true)
+        enable: false
+        
+        # You can define your own normalizer service (default: see id below)
+        normalizer_id: best_it_commercetools_filter.normalizer_term.category_normalizer
+        
+        # You can define your own cache pool (default: see id below)
+        cache_id: cache.app
+        
+        # Time in seconds (default: 86400)
+        cache_life_time: 60        
 ```
 
 ## Usage
@@ -227,6 +262,15 @@ own if you implement the _ProductNormalizerInterface_ and add the service id to 
 * EmptyProductNormalizer: Just return the _ProductProjection_ without normalization
 
 _EmptyProductNormalizer_ will be use if you don't fill the _product_normalizer_id_ Parameter (@ config.yml).
+
+### Term Normalizer
+There are cases where you have to normalize facet terms. Commercetools only ships enum keys and categories id for example, which aren't enough for your frontend.
+This bundle contains two default normalizers:
+
+* CategoryNormalizer: Converts category id's to there real name
+* EnumAttributeNormalizer: Converts enum keys to there label
+
+But you can define your own TermNormalizer as well. Just implement the _TermNormalizerInterface_ and set the service id in your config.
 
 ### Config Provider id
 

--- a/src/FilterBundle/DependencyInjection/BestItCommercetoolsFilterExtension.php
+++ b/src/FilterBundle/DependencyInjection/BestItCommercetoolsFilterExtension.php
@@ -25,15 +25,51 @@ class BestItCommercetoolsFilterExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
+
+        // Fix deprecated config
+        $config['enum_normalizer']['cache_life_time'] = $config['cache_life_time'];
+
         $container->setParameter('best_it_commercetools_filter.config', $config ?? []);
 
         // Set alias services
         $container->setAlias('best_it_commercetools_filter.normalizer.product', $config['product_normalizer_id']);
         $container->setAlias('best_it_commercetools_filter.request.client', $config['client_id']);
         $container->setAlias('best_it_commercetools_filter.generator.url', $config['url_generator_id']);
+        $container->setAlias(
+            'best_it_commercetools_filter.normalizer.category.cache',
+            $config['category_normalizer']['cache_id']
+        );
+        $container->setAlias(
+            'best_it_commercetools_filter.normalizer.enum.cache',
+            $config['enum_normalizer']['cache_id']
+        );
+        $container->setAlias(
+            'best_it_commercetools_filter.normalizer.enum',
+            $config['enum_normalizer']['normalizer_id']
+        );
+        $container->setAlias(
+            'best_it_commercetools_filter.normalizer.category',
+            $config['category_normalizer']['normalizer_id']
+        );
 
         // Set parameters
-        $container->setParameter('best_it_commercetools_filter.cache_life_time', $config['cache_life_time']);
+        $container->setParameter(
+            'best_it_commercetools_filter.config.enum_normalizer.cache_life_time',
+            $config['enum_normalizer']['cache_life_time']
+        );
+        $container->setParameter(
+            'best_it_commercetools_filter.config.category_normalizer.cache_life_time',
+            $config['category_normalizer']['cache_life_time']
+        );
+
+        // Disable services
+        if ($config['enum_normalizer']['enable'] === false) {
+            $container->removeDefinition('best_it_commercetools_filter.listener_term.enum_attribute_listener');
+        }
+
+        if ($config['category_normalizer']['enable'] === false) {
+            $container->removeDefinition('best_it_commercetools_filter.listener_term.category_listener');
+        }
 
         // Set config factory
         $container

--- a/src/FilterBundle/DependencyInjection/Configuration.php
+++ b/src/FilterBundle/DependencyInjection/Configuration.php
@@ -49,7 +49,7 @@ class Configuration implements ConfigurationInterface
                         ->defaultValue('best_it_commercetools_filter.generator.default_filter_url_generator')
                     ->end()
                     ->scalarNode('cache_life_time')
-                        ->info('Cache life time. Enum Attribute labels are cached to minimize CommerceTools requests.')
+                        ->info('DEPRECATED! Cache life time. Enum Attribute labels are cached to minimize CommerceTools requests.')
                         ->defaultValue(86400)
                     ->end()
                 ->end()
@@ -58,6 +58,8 @@ class Configuration implements ConfigurationInterface
             ->append($this->getViewNode())
             ->append($this->getSuggestNode())
             ->append($this->getSearchNode())
+            ->append($this->getEnumNormalizerNode())
+            ->append($this->getCategoryNormalizerNode())
             ->append($this->getFacetsNode());
 
         return $builder;
@@ -206,6 +208,74 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
+     * Add the config for enum normalization
+     *
+     * @return ArrayNodeDefinition
+     */
+    private function getEnumNormalizerNode(): ArrayNodeDefinition
+    {
+        $node = (new TreeBuilder())->root('enum_normalizer');
+
+        $node
+            ->info('Normalization for enum')
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->booleanNode('enable')
+                    ->info('Enable the normalization (default: true)')
+                    ->defaultTrue()
+                ->end()
+                ->scalarNode('normalizer_id')
+                    ->info('Optional Service id for own normalizer')
+                    ->defaultValue('best_it_commercetools_filter.normalizer_term.enum_attribute_normalizer')
+                ->end()
+                ->scalarNode('cache_id')
+                    ->info('Service id if for cache (default: cache.app)')
+                    ->defaultValue('cache.app')
+                ->end()
+                ->integerNode('cache_life_time')
+                    ->info('Cache life time. Enum Attribute labels are cached to minimize CommerceTools requests.')
+                    ->defaultValue(86400)
+                ->end()
+            ->end();
+
+        return $node;
+    }
+
+    /**
+     * Add the config for category normalization
+     *
+     * @return ArrayNodeDefinition
+     */
+    private function getCategoryNormalizerNode(): ArrayNodeDefinition
+    {
+        $node = (new TreeBuilder())->root('category_normalizer');
+
+        $node
+            ->info('Normalization for categories name')
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->booleanNode('enable')
+                    ->info('Enable the normalization (default: true)')
+                    ->defaultTrue()
+                ->end()
+                ->scalarNode('normalizer_id')
+                    ->info('Optional service id for own normalizer')
+                    ->defaultValue('best_it_commercetools_filter.normalizer_term.category_normalizer')
+                ->end()
+                ->scalarNode('cache_id')
+                    ->info('Service id if for cache (default: cache.app)')
+                    ->defaultValue('cache.app')
+                ->end()
+                ->integerNode('cache_life_time')
+                    ->info('Cache life time. Categories labels are cached to minimize CommerceTools requests.')
+                    ->defaultValue(86400)
+                ->end()
+            ->end();
+
+        return $node;
+    }
+
+    /**
      * Add the config for sorting
      *
      * @return ArrayNodeDefinition
@@ -231,7 +301,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->children()
                             ->scalarNode('query')
-                                ->info('Api query for sdk')
+                                ->info('Api query for sdk (default: null for relevance sorting) ')
                                 ->defaultNull()
                             ->end()
                             ->scalarNode('translation')

--- a/src/FilterBundle/Event/Facet/TermEvent.php
+++ b/src/FilterBundle/Event/Facet/TermEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace BestIt\Commercetools\FilterBundle\Event\Facet;
+
+use BestIt\Commercetools\FilterBundle\Model\Facet\FacetConfig;
+use BestIt\Commercetools\FilterBundle\Model\Term\Term;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event for manipulate terms
+ *
+ * @author     chowanski <chowanski@bestit-online.de>
+ * @package    BestIt\Commercetools\FilterBundle
+ * @subpackage Event\Facet
+ */
+class TermEvent extends Event
+{
+    /**
+     * The config
+     *
+     * @var FacetConfig
+     */
+    private $config;
+
+    /**
+     * The term
+     *
+     * @var Term
+     */
+    private $term;
+
+    /**
+     * TermEvent constructor.
+     *
+     * @param FacetConfig $config
+     * @param Term $term
+     */
+    public function __construct(FacetConfig $config, Term $term)
+    {
+        $this->config = $config;
+        $this->term = $term;
+    }
+
+    /**
+     * Get config
+     *
+     * @return FacetConfig
+     */
+    public function getConfig(): FacetConfig
+    {
+        return $this->config;
+    }
+
+    /**
+     * Get term
+     *
+     * @return Term
+     */
+    public function getTerm(): Term
+    {
+        return $this->term;
+    }
+}

--- a/src/FilterBundle/FilterEvent.php
+++ b/src/FilterBundle/FilterEvent.php
@@ -17,4 +17,11 @@ class FilterEvent
      * @Event("BestIt\Commercetools\FilterBundle\Event\Request\ProductProjectionSearchRequestEvent")
      */
     const PRODUCTS_REQUEST_POST = 'best_it_commercetools_filter.event.filter.products.request.post';
+
+    /**
+     * Event for collecting and extend terms
+     *
+     * @Event("BestIt\Commercetools\FilterBundle\Event\Facet\TermEvent")
+     */
+    const FACET_TERM_COLLECT = 'best_it_commercetools_filter.event.filter.facets.term_collect';
 }

--- a/src/FilterBundle/Listener/Term/CategoryListener.php
+++ b/src/FilterBundle/Listener/Term/CategoryListener.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace BestIt\Commercetools\FilterBundle\Listener\Term;
+
+use BestIt\Commercetools\FilterBundle\Enum\FacetType;
+use BestIt\Commercetools\FilterBundle\Event\Facet\TermEvent;
+use BestIt\Commercetools\FilterBundle\FilterEvent;
+use BestIt\Commercetools\FilterBundle\Normalizer\TermNormalizerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class CategoryListener
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\Commercetools\FilterBundle\Listener\Term
+ */
+class CategoryListener implements EventSubscriberInterface
+{
+    /**
+     * Term normalizer
+     *
+     * @var TermNormalizerInterface
+     */
+    private $normalizer;
+
+    /**
+     * CategoryListener constructor.
+     *
+     * @param TermNormalizerInterface $normalizer
+     */
+    public function __construct(TermNormalizerInterface $normalizer)
+    {
+        $this->normalizer = $normalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            FilterEvent::FACET_TERM_COLLECT => 'onCollect'
+        ];
+    }
+
+    /**
+     * On collect
+     *
+     * @param TermEvent $event
+     *
+     * @return void
+     */
+    public function onCollect(TermEvent $event)
+    {
+        $config = $event->getConfig();
+        $term = $event->getTerm();
+
+        if ($event->getConfig()->getType() === FacetType::CATEGORY) {
+            $this->normalizer->normalize($config, $term);
+        }
+    }
+}

--- a/src/FilterBundle/Listener/Term/EnumAttributeListener.php
+++ b/src/FilterBundle/Listener/Term/EnumAttributeListener.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace BestIt\Commercetools\FilterBundle\Listener\Term;
+
+use BestIt\Commercetools\FilterBundle\Enum\FacetType;
+use BestIt\Commercetools\FilterBundle\Event\Facet\TermEvent;
+use BestIt\Commercetools\FilterBundle\FilterEvent;
+use BestIt\Commercetools\FilterBundle\Normalizer\TermNormalizerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class EnumAttributeListener
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\Commercetools\FilterBundle\Listener\Term
+ */
+class EnumAttributeListener implements EventSubscriberInterface
+{
+    /**
+     * Term normalizer
+     *
+     * @var TermNormalizerInterface
+     */
+    private $normalizer;
+
+    /**
+     * EnumAttributeListener constructor.
+     *
+     * @param TermNormalizerInterface $normalizer
+     */
+    public function __construct(TermNormalizerInterface $normalizer)
+    {
+        $this->normalizer = $normalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            FilterEvent::FACET_TERM_COLLECT => 'onCollect'
+        ];
+    }
+
+    /**
+     * On collect normalize enum term
+     *
+     * @param TermEvent $event
+     *
+     * @return void
+     */
+    public function onCollect(TermEvent $event)
+    {
+        $config = $event->getConfig();
+        $term = $event->getTerm();
+
+        if (in_array($event->getConfig()->getType(), [FacetType::ENUM, FacetType::LENUM], true)) {
+            $this->normalizer->normalize($config, $term);
+        }
+    }
+}

--- a/src/FilterBundle/Model/Facet/FacetConfigCollection.php
+++ b/src/FilterBundle/Model/Facet/FacetConfigCollection.php
@@ -2,6 +2,9 @@
 
 namespace BestIt\Commercetools\FilterBundle\Model\Facet;
 
+use ArrayIterator;
+use IteratorAggregate;
+
 /**
  * Collection for facet config
  *
@@ -9,7 +12,7 @@ namespace BestIt\Commercetools\FilterBundle\Model\Facet;
  * @package    BestIt\Commercetools\FilterBundle
  * @subpackage Model\Facet
  */
-class FacetConfigCollection
+class FacetConfigCollection implements IteratorAggregate
 {
     /**
      * Array of configs
@@ -76,5 +79,13 @@ class FacetConfigCollection
         }
 
         return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->all());
     }
 }

--- a/src/FilterBundle/Model/Term/Term.php
+++ b/src/FilterBundle/Model/Term/Term.php
@@ -23,7 +23,7 @@ class Term
      *
      * @var int
      */
-    private $count = 0;
+    private $count;
 
     /**
      * The title
@@ -31,6 +31,20 @@ class Term
      * @var string|null
      */
     private $title;
+
+    /**
+     * Term constructor.
+     *
+     * @param int $count
+     * @param null|string $term
+     * @param null|string $title
+     */
+    public function __construct(int $count = 0, string $term = null, string $title = null)
+    {
+        $this->term = $term;
+        $this->count = $count;
+        $this->title = $title;
+    }
 
     /**
      * Matched results

--- a/src/FilterBundle/Normalizer/Term/CategoryNormalizer.php
+++ b/src/FilterBundle/Normalizer/Term/CategoryNormalizer.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace BestIt\Commercetools\FilterBundle\Normalizer\Term;
+
+use BestIt\Commercetools\FilterBundle\Model\Facet\FacetConfig;
+use BestIt\Commercetools\FilterBundle\Model\Term\Term;
+use BestIt\Commercetools\FilterBundle\Normalizer\TermNormalizerInterface;
+use Commercetools\Commons\Helper\QueryHelper;
+use Commercetools\Core\Client;
+use Commercetools\Core\Model\Category\Category;
+use Commercetools\Core\Request\Categories\CategoryQueryRequest;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class CategoryNormalizer
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\Commercetools\FilterBundle\Normalizer\Term
+ */
+class CategoryNormalizer implements TermNormalizerInterface
+{
+    /**
+     * @var string CACHE_KEY
+     */
+    const CACHE_KEY = 'best_it_commercetools_filter.normalizer_term.category_normalizer';
+
+    /**
+     * Cache pool
+     *
+     * @var CacheItemPoolInterface
+     */
+    private $cacheItemPool;
+
+    /**
+     * Cache time value.
+     *
+     * @var int $cacheTime
+     */
+    private $cacheTime;
+
+    /**
+     * CommerceTools client.
+     *
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * The query helper
+     *
+     * @var QueryHelper
+     */
+    private $queryHelper;
+
+    /**
+     * Memory cached labels
+     *
+     * @var array
+     */
+    private $labels = [];
+
+    /**
+     * CategoryNormalizer constructor.
+     *
+     * @param Client $client
+     * @param CacheItemPoolInterface $cacheItemPool
+     * @param int $cacheTime
+     * @param QueryHelper $queryHelper
+     */
+    public function __construct(
+        Client $client,
+        CacheItemPoolInterface $cacheItemPool,
+        int $cacheTime,
+        QueryHelper $queryHelper
+    ) {
+        $this->client = $client;
+        $this->cacheItemPool = $cacheItemPool;
+        $this->cacheTime = $cacheTime;
+        $this->queryHelper = $queryHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize(FacetConfig $config, Term $term): Term
+    {
+        $cacheItem = $this->cacheItemPool->getItem(self::CACHE_KEY);
+
+        // Load from cache when memory cache is empty
+        if (count($this->labels) === 0 && $cacheItem->isHit()) {
+            $this->labels = $cacheItem->get();
+        }
+
+        // Fetch all categories if label is missing and save new cache
+        if (!array_key_exists($term->getTitle(), $this->labels)) {
+            $this->fetchCategories();
+
+            $cacheItem->set($this->labels);
+            $cacheItem->expiresAfter($this->cacheTime);
+            $this->cacheItemPool->save($cacheItem);
+        }
+
+        // Save value
+        $term->setTitle($this->labels[$term->getTitle()] ?? $term->getTitle());
+
+        return $term;
+    }
+
+    /**
+     * Fetch all categories from commercetools.
+     *
+     * @return void
+     */
+    private function fetchCategories()
+    {
+        $request = CategoryQueryRequest::of();
+
+        /** @var Category $category */
+        foreach ($this->queryHelper->getAll($this->client, $request) as $category) {
+            $name = $category->getName() ? $category->getName()->getLocalized() : $category->getId();
+            $this->labels[$category->getId()] = $name;
+        }
+    }
+}

--- a/src/FilterBundle/Normalizer/TermNormalizerInterface.php
+++ b/src/FilterBundle/Normalizer/TermNormalizerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BestIt\Commercetools\FilterBundle\Normalizer;
+
+use BestIt\Commercetools\FilterBundle\Model\Facet\FacetConfig;
+use BestIt\Commercetools\FilterBundle\Model\Term\Term;
+
+/**
+ * Normalizer interface for terms
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\Commercetools\FilterBundle\Normalizer
+ */
+interface TermNormalizerInterface
+{
+    /**
+     * Normalize term
+     *
+     * @param FacetConfig $config
+     * @param Term $term
+     *
+     * @return Term
+     */
+    public function normalize(FacetConfig $config, Term $term) :Term;
+}

--- a/src/FilterBundle/Resources/config/services.yml
+++ b/src/FilterBundle/Resources/config/services.yml
@@ -39,7 +39,7 @@ services:
       class: BestIt\Commercetools\FilterBundle\Factory\FacetCollectionFactory
       arguments:
           - '@best_it_commercetools_filter.model.facet_config_collection'
-          - '@best_it_commercetools_filter.helper.enum_attribute_helper'
+          - '@event_dispatcher'
 
   best_it_commercetools_filter.provider.empty_facet_config_provider:
       class: BestIt\Commercetools\FilterBundle\Provider\EmptyFacetConfigProvider
@@ -79,6 +79,35 @@ services:
       class: BestIt\Commercetools\FilterBundle\Generator\DefaultFilterUrlGenerator
       arguments: ['@router']
 
-  best_it_commercetools_filter.helper.enum_attribute_helper:
-      class: BestIt\Commercetools\FilterBundle\Helper\EnumAttributeHelper
-      arguments: ['@best_it_commercetools_filter.request.client', '@cache.app', '%best_it_commercetools_filter.cache_life_time%']
+  best_it_commercetools_filter.listener_term.enum_attribute_listener:
+      class: BestIt\Commercetools\FilterBundle\Listener\Term\EnumAttributeListener
+      arguments:
+          - '@best_it_commercetools_filter.normalizer.enum'
+      tags:
+          - { name: kernel.event_subscriber }
+
+  best_it_commercetools_filter.normalizer_term.enum_attribute_normalizer:
+      class: BestIt\Commercetools\FilterBundle\Normalizer\Term\EnumAttributeNormalizer
+      arguments:
+          - '@best_it_commercetools_filter.request.client'
+          - '@best_it_commercetools_filter.normalizer.enum.cache'
+          - '%best_it_commercetools_filter.config.enum_normalizer.cache_life_time%'
+          - '@best_it_commercetools_filter.commercetools.commons.helper.query_helper'
+
+  best_it_commercetools_filter.listener_term.category_listener:
+      class: BestIt\Commercetools\FilterBundle\Listener\Term\CategoryListener
+      arguments:
+          - '@best_it_commercetools_filter.normalizer.category'
+      tags:
+          - { name: kernel.event_subscriber }
+
+  best_it_commercetools_filter.normalizer_term.category_normalizer:
+      class: BestIt\Commercetools\FilterBundle\Normalizer\Term\CategoryNormalizer
+      arguments:
+          - '@best_it_commercetools_filter.request.client'
+          - '@best_it_commercetools_filter.normalizer.category.cache'
+          - '%best_it_commercetools_filter.config.category_normalizer.cache_life_time%'
+          - '@best_it_commercetools_filter.commercetools.commons.helper.query_helper'
+
+  best_it_commercetools_filter.commercetools.commons.helper.query_helper:
+      class: Commercetools\Commons\Helper\QueryHelper

--- a/src/FilterBundle/Tests/Unit/Form/FilterTypeTest.php
+++ b/src/FilterBundle/Tests/Unit/Form/FilterTypeTest.php
@@ -77,10 +77,10 @@ class FilterTypeTest extends TestCase
 
         $textFacet->setTerms(
             (new TermCollection())
-                ->addTerm((new Term))// Term without title
-                ->addTerm(($cTerm = (new Term)->setTitle('cccFooBar')->setCount(12)->setTerm('cccFooBar')))
-                ->addTerm(($aTerm = (new Term)->setTitle('aaaFooBar')->setCount(45)->setTerm('aaaFooBar')))
-                ->addTerm(($bTerm = (new Term)->setTitle('bbbFooBar')->setCount(16)->setTerm('bbbFooBar')))
+                ->addTerm(new Term(0))// Term without title
+                ->addTerm($cTerm = new Term(12, 'cccFooBar', 'cccFooBar'))
+                ->addTerm($aTerm = new Term(45, 'aaaFooBar', 'aaaFooBar'))
+                ->addTerm($bTerm = new Term(16, 'bbbFooBar', 'bbbFooBar'))
         );
 
         $facetCollection->addFacet($textFacet);

--- a/src/FilterBundle/Tests/Unit/Model/Term/TermTest.php
+++ b/src/FilterBundle/Tests/Unit/Model/Term/TermTest.php
@@ -2,6 +2,7 @@
 
 namespace BestIt\Commercetools\FilterBundle\Tests\Unit\Model\Term;
 
+use BestIt\Commercetools\FilterBundle\Event\Facet\TermEvent;
 use BestIt\Commercetools\FilterBundle\Model\Pagination\Pagination;
 use BestIt\Commercetools\FilterBundle\Model\Term\Term;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +31,20 @@ class TermTest extends TestCase
     public function setUp()
     {
         $this->fixture = new Term();
+    }
+
+    /**
+     * Test setter / getter for title property
+     *
+     * @return void
+     */
+    public function testConstructor()
+    {
+        $term = new Term(45, 'foo-term', 'bar-label');
+
+        self::assertEquals('bar-label', $term->getTitle());
+        self::assertEquals(45, $term->getCount());
+        self::assertEquals('foo-term', $term->getTerm());
     }
 
     /**


### PR DESCRIPTION
Die Terms (also mögliche Filterbare Werte der Facets) sind leider nicht immer eigenständige Begriffe. Kategorien werden zb. als ID ausgegeben, womit der Kunde nichts anfangen kann. 

Daher muss hier nachträglich eine "Übersetzung" stattfinden. Das sehe ich allerdings nicht zwingend in der Aufgabe vom FilterBundle. Daher ein Event eingefügt, damit wir den Term beliebig anpassen können.

Die bisher hart verdrahte ENUM Übersetzung habe ich als Listener ausgelagert und nutzt nun dieses Event. Hier stellt sich auch die Frage, ob das zwingend das FilterBundle die ENUM Übersetzung durchführen muss. Fände hier ein eigenständiges Bundle als Extension zum FilterBundle sinnvoller. Aber habe es erstmal so gelassen.