### PR TITLE
Fix filter / facet handling (empty facet combinations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## Unreleased
+### Bugfix
+- Fix wrong facet results which caused filter combinations with zero products @chowanski
+- Fix wrong facet sorting (high to low) @chowanski
+
 ## [6.1.0] - 2017-10-05
 ### Added
-- Add new event for collect and manipulate facet terms (see FilterEvent.php) @chowanski
+- Add new event to collect and manipulate facet terms (see FilterEvent.php) @chowanski
 - New interface for term manipulation: _TermNormalizerInterface_ @chowanski
 - Detailed configuration (service id, cache id, cache time, state) for enum term normalization @chowanski
 - Detailed configuration (service id, cache id, cache time, state) for category term normalization @chowanski

--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ _EmptyProductNormalizer_ will be use if you don't fill the _product_normalizer_i
 There are cases where you have to normalize facet terms. Commercetools only ships enum keys and categories id for example, which aren't enough for your frontend.
 This bundle contains two default normalizers:
 
-* CategoryNormalizer: Converts category id's to there real name
-* EnumAttributeNormalizer: Converts enum keys to there label
+* CategoryNormalizer: Converts category id's to their real name
+* EnumAttributeNormalizer: Converts enum keys to their label
 
 But you can define your own TermNormalizer as well. Just implement the _TermNormalizerInterface_ and set the service id in your config.
 

--- a/src/FilterBundle/Builder/FacetBuilder.php
+++ b/src/FilterBundle/Builder/FacetBuilder.php
@@ -111,7 +111,7 @@ class FacetBuilder
 
                 if ($facetConfig->isMultiSelect()) {
                     $request->addFilter($filter);
-                    $request->addFacet($filter);
+                    $request->addFilterFacets($filter);
                 } else {
                     $request->addFilterQuery($filter);
                 }

--- a/src/FilterBundle/Builder/RequestBuilder.php
+++ b/src/FilterBundle/Builder/RequestBuilder.php
@@ -94,8 +94,7 @@ class RequestBuilder
 
         // Filter to category if exists
         if ($category = $context->getCategory()) {
-            $request->addFilter($filter = new Filter('categories.id', $category->getId()));
-            $request->addFilterQuery($filter);
+            $request->addFilterQuery(new Filter('categories.id', $category->getId()));
         }
 
         // Filter to search value if exists

--- a/src/FilterBundle/Model/Facet/FacetCollection.php
+++ b/src/FilterBundle/Model/Facet/FacetCollection.php
@@ -46,7 +46,7 @@ class FacetCollection implements IteratorAggregate
         usort(
             $facetsSorted,
             function (Facet $a, Facet $b) {
-                return $a->getConfig()->getWeight() <=> $b->getConfig()->getWeight();
+                return $b->getConfig()->getWeight() <=> $a->getConfig()->getWeight();
             }
         );
 


### PR DESCRIPTION
Das Bundle gab bis dato leider auch Filtermöglichkeiten ans Frontend, die zu keinem Ergebnis führen. Dies ist so natürlich nicht gewollt - die Facets müssen ebenfalls korrekt gefiltert werden, was mit diesem Fix behoben wird.

Diese Anpassung ist sehr klein - hat aber große Auswirkungen. Ausgiebig im Projekt getestet und keine Auffälligkeiten mehr festgestellt.

Sofern im Projekt die Requests manipuliert werden (zb. um Preis-Filter anzugeben), muss dort natürlich ebenfalls auf ein korrektes Filterhandling geachtet werden.