### PR TITLE
Fix ltext field / add localization argument for filter / suggest / ke…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 ## Unreleased
+### Added
+- New argument for filter manager / suggest manager for defining search language @chowanski
+
+### Removed
+- Language from commercetools client will be ignored @chowanski
+
 ### Bugfix
 - Fix wrong facet results which caused filter combinations with zero products @chowanski
 - Fix wrong facet sorting (high to low) @chowanski
+- Fix wrong ltext facet definition @chowanski
 
 ## [6.1.0] - 2017-10-05
 ### Added

--- a/src/FilterBundle/Builder/FacetBuilder.php
+++ b/src/FilterBundle/Builder/FacetBuilder.php
@@ -6,6 +6,7 @@ use BestIt\Commercetools\FilterBundle\Form\Transformer\PriceMaxDataTransformer;
 use BestIt\Commercetools\FilterBundle\Form\Transformer\PriceMinDataTransformer;
 use BestIt\Commercetools\FilterBundle\Model\Facet\FacetConfig;
 use BestIt\Commercetools\FilterBundle\Model\Facet\FacetConfigCollection;
+use BestIt\Commercetools\FilterBundle\Model\Search\SearchContext;
 use Commercetools\Core\Model\Product\Search\Facet;
 use Commercetools\Core\Model\Product\Search\Filter;
 use Commercetools\Core\Model\Product\Search\FilterSubtree;
@@ -42,11 +43,12 @@ class FacetBuilder
      * Build facets to request
      *
      * @param ProductProjectionSearchRequest $request
+     * @param SearchContext $context
      * @param array $values
      *
      * @return ProductProjectionSearchRequest
      */
-    public function build(ProductProjectionSearchRequest $request, array $values = []): ProductProjectionSearchRequest
+    public function build(ProductProjectionSearchRequest $request, SearchContext $context, array $values = []): ProductProjectionSearchRequest
     {
         $aliases = array_map(
             function (FacetConfig $facetConfig) {
@@ -57,9 +59,11 @@ class FacetBuilder
 
         foreach ($aliases as $facetAlias) {
             $facetConfig = $this->facetConfigCollection->findByAlias($facetAlias);
-            $name = $facetConfig->getFilterField();
+            $name = $facetConfig->getFilterField($context->getLanguage());
 
-            $request->addFacet(Facet::ofName($facetConfig->getFacetField())->setAlias($facetConfig->getAlias()));
+            $request->addFacet(
+                Facet::ofName($facetConfig->getFacetField($context->getLanguage()))->setAlias($facetConfig->getAlias())
+            );
 
             // force price range to be calculate out of full result facets
             if ($facetConfig->getType() === 'range') {

--- a/src/FilterBundle/Builder/RequestBuilder.php
+++ b/src/FilterBundle/Builder/RequestBuilder.php
@@ -99,9 +99,7 @@ class RequestBuilder
 
         // Filter to search value if exists
         if ($search = $context->getSearch()) {
-            foreach ($this->client->getConfig()->getContext()->getLanguages() as $language) {
-                $request->addParam(sprintf('text.%s', $language), $search);
-            }
+            $request->addParam(sprintf('text.%s', $context->getLanguage()), $search);
 
             // Fuzzy
             $fuzzyConfig = $context->getConfig()->getFuzzyConfig();
@@ -113,7 +111,7 @@ class RequestBuilder
 
         $builder = new FacetBuilder($this->facetConfigCollection);
         $resolvedValues = $builder->resolve($this->decode($context->getQuery()));
-        $request = $builder->build($request, $resolvedValues);
+        $request = $builder->build($request, $context, $resolvedValues);
 
         $event = new ProductProjectionSearchRequestEvent($request);
         $this->eventDispatcher->dispatch(FilterEvent::PRODUCTS_REQUEST_POST, $event);

--- a/src/FilterBundle/Enum/FacetType.php
+++ b/src/FilterBundle/Enum/FacetType.php
@@ -25,7 +25,7 @@ class FacetType
      *
      * @var string
      */
-    const LOCALIZED_TEXT = 'localized_text';
+    const LOCALIZED_TEXT = 'ltext';
 
     /**
      * Facet enum type

--- a/src/FilterBundle/Factory/SearchContextFactory.php
+++ b/src/FilterBundle/Factory/SearchContextFactory.php
@@ -50,10 +50,11 @@ class SearchContextFactory
      *
      * @param Request $request
      * @param Category $category
+     * @param string $language
      *
      * @return SearchContext
      */
-    public function createFromCategory(Request $request, Category $category): SearchContext
+    public function createFromCategory(Request $request, Category $category, string $language): SearchContext
     {
         $config = $this->getConfig();
 
@@ -83,7 +84,8 @@ class SearchContextFactory
                 'config' => $config,
                 'route' => $category,
                 'baseUrl' => $this->getFilterUrlGenerator()->generateByCategory($request, $category),
-                'category' => $category
+                'category' => $category,
+                'language' => $language
             ]
         );
 
@@ -94,11 +96,12 @@ class SearchContextFactory
      * Create the context from request
      *
      * @param Request $request
+     * @param string $language
      * @param string|null $search
      *
      * @return SearchContext
      */
-    public function createFromSearch(Request $request, string $search = null): SearchContext
+    public function createFromSearch(Request $request, string $language, string $search = null): SearchContext
     {
         $config = $this->getConfig();
 
@@ -128,7 +131,8 @@ class SearchContextFactory
                 'config' => $config,
                 'route' => 'search_index',
                 'baseUrl' => $this->getFilterUrlGenerator()->generateBySearch($request, $search),
-                'search' => $search
+                'search' => $search,
+                'language' => $language
             ]
         );
 

--- a/src/FilterBundle/Manager/FilterManager.php
+++ b/src/FilterBundle/Manager/FilterManager.php
@@ -111,9 +111,9 @@ class FilterManager implements FilterManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function listing(Request $request, Category $category): SearchResult
+    public function listing(Request $request, Category $category, string $language = 'de'): SearchResult
     {
-        $context = $this->getContextFactory()->createFromCategory($request, $category);
+        $context = $this->getContextFactory()->createFromCategory($request, $category, $language);
         $sorting = $this->getSortingFactory()->create($context);
 
         $rawResponse = $this->getRequestBuilder()->execute($context, $sorting);
@@ -126,9 +126,9 @@ class FilterManager implements FilterManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function search(Request $request, string $search = null): SearchResult
+    public function search(Request $request, string $search = null, string $language = 'de'): SearchResult
     {
-        $context = $this->getContextFactory()->createFromSearch($request, $search);
+        $context = $this->getContextFactory()->createFromSearch($request, $language, $search);
         $sorting = $this->getSortingFactory()->create($context);
 
         $rawResponse = $this->getRequestBuilder()->execute($context, $sorting);

--- a/src/FilterBundle/Manager/FilterManagerInterface.php
+++ b/src/FilterBundle/Manager/FilterManagerInterface.php
@@ -20,18 +20,20 @@ interface FilterManagerInterface
      *
      * @param Request $request
      * @param Category $category
+     * @param string $language
      *
      * @return SearchResult
      */
-    public function listing(Request $request, Category $category): SearchResult;
+    public function listing(Request $request, Category $category, string $language = 'de'): SearchResult;
 
     /**
      * Perform a search request
      *
      * @param Request $request
      * @param string $search
+     * @param string $language
      *
      * @return SearchResult
      */
-    public function search(Request $request, string $search = null): SearchResult;
+    public function search(Request $request, string $search = null, string $language = 'de'): SearchResult;
 }

--- a/src/FilterBundle/Manager/SuggestManager.php
+++ b/src/FilterBundle/Manager/SuggestManager.php
@@ -77,13 +77,11 @@ class SuggestManager implements SuggestManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function getKeywords(string $keyword, int $max): KeywordsResult
+    public function getKeywords(string $keyword, int $max, string $language = 'de'): KeywordsResult
     {
         $collection = [];
         $request = new ProductsSuggestRequest();
-        foreach ($this->client->getConfig()->getContext()->getLanguages() as $language) {
-            $request->addKeyword($language, $keyword);
-        }
+        $request->addKeyword($language, $keyword);
 
         $request->limit($max);
         $request->fuzzy(false);
@@ -126,12 +124,10 @@ class SuggestManager implements SuggestManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function getProducts(string $keyword, int $max): SuggestResult
+    public function getProducts(string $keyword, int $max, string $language = 'de'): SuggestResult
     {
         $request = ProductProjectionSearchRequest::of();
-        foreach ($this->client->getConfig()->getContext()->getLanguages() as $language) {
-            $request->addParam(sprintf('text.%s', $language), $keyword);
-        }
+        $request->addParam(sprintf('text.%s', $language), $keyword);
 
         $request->limit($max);
         $request->fuzzy(false);

--- a/src/FilterBundle/Manager/SuggestManagerInterface.php
+++ b/src/FilterBundle/Manager/SuggestManagerInterface.php
@@ -20,22 +20,20 @@ interface SuggestManagerInterface
      *
      * @param string $keyword
      * @param int $max
-     *
-     * @throws ApiException
+     * @param string $language
      *
      * @return KeywordsResult
      */
-    public function getKeywords(string $keyword, int $max): KeywordsResult;
+    public function getKeywords(string $keyword, int $max, string $language = 'de'): KeywordsResult;
 
     /**
      * Get products by keyword
      *
      * @param string $keyword
      * @param int $max
-     *
-     * @throws ApiException
+     * @param string $language
      *
      * @return SuggestResult
      */
-    public function getProducts(string $keyword, int $max): SuggestResult;
+    public function getProducts(string $keyword, int $max, string $language = 'de'): SuggestResult;
 }

--- a/src/FilterBundle/Model/Facet/FacetConfig.php
+++ b/src/FilterBundle/Model/Facet/FacetConfig.php
@@ -101,9 +101,11 @@ class FacetConfig
     /**
      * Get facetField
      *
+     * @param string $language
+     *
      * @return string
      */
-    public function getFacetField(): string
+    public function getFacetField(string $language): string
     {
         if ($this->facetField === null) {
             switch ($this->type) {
@@ -111,7 +113,7 @@ class FacetConfig
                     $this->facetField = sprintf('variants.attributes.%s', $this->getField());
                     break;
                 case FacetType::LOCALIZED_TEXT:
-                    $this->facetField = sprintf('variants.attributes.de.%s', $this->getField());
+                    $this->facetField = sprintf('variants.attributes.%s.%s', $this->getField(), $language);
                     break;
                 case FacetType::ENUM:
                 case FacetType::LENUM:
@@ -171,9 +173,11 @@ class FacetConfig
     /**
      * Get filterField
      *
+     * @param string $language
+     *
      * @return string
      */
-    public function getFilterField(): string
+    public function getFilterField(string $language): string
     {
         if ($this->filterField === null) {
             switch ($this->type) {
@@ -181,7 +185,7 @@ class FacetConfig
                     $this->filterField = sprintf('variants.attributes.%s', $this->getField());
                     break;
                 case FacetType::LOCALIZED_TEXT:
-                    $this->filterField = sprintf('variants.attributes.de.%s', $this->getField());
+                    $this->filterField = sprintf('variants.attributes.%s.%s', $this->getField(), $language);
                     break;
                 case FacetType::ENUM:
                 case FacetType::LENUM:

--- a/src/FilterBundle/Model/Search/SearchContext.php
+++ b/src/FilterBundle/Model/Search/SearchContext.php
@@ -80,6 +80,13 @@ class SearchContext
     private $baseUrl;
 
     /**
+     * The language for searching
+     *
+     * @var string
+     */
+    private $language;
+
+    /**
      * Context constructor
      *
      * @param array $values
@@ -306,6 +313,30 @@ class SearchContext
     public function setBaseUrl(string $baseUrl): SearchContext
     {
         $this->baseUrl = $baseUrl;
+
+        return $this;
+    }
+
+    /**
+     * Get language
+     *
+     * @return string
+     */
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    /**
+     * Set language
+     *
+     * @param string $language
+     *
+     * @return SearchContext
+     */
+    public function setLanguage(string $language): SearchContext
+    {
+        $this->language = $language;
 
         return $this;
     }

--- a/src/FilterBundle/Tests/Unit/Builder/FacetBuilderTest.php
+++ b/src/FilterBundle/Tests/Unit/Builder/FacetBuilderTest.php
@@ -6,6 +6,7 @@ use BestIt\Commercetools\FilterBundle\Builder\FacetBuilder;
 use BestIt\Commercetools\FilterBundle\Enum\FacetType;
 use BestIt\Commercetools\FilterBundle\Model\Facet\FacetConfig;
 use BestIt\Commercetools\FilterBundle\Model\Facet\FacetConfigCollection;
+use BestIt\Commercetools\FilterBundle\Model\Search\SearchContext;
 use Commercetools\Core\Request\Products\ProductProjectionSearchRequest;
 use PHPUnit\Framework\TestCase;
 
@@ -62,7 +63,7 @@ class FacetBuilderTest extends TestCase
                 ->setName('foobar')
                 ->setField('foobar')
                 ->setAlias('foobar')
-                ->setType(FacetType::TEXT)
+                ->setType(FacetType::LOCALIZED_TEXT)
         );
 
         $this->fixture = new FacetBuilder($this->facetConfigCollection);
@@ -77,7 +78,11 @@ class FacetBuilderTest extends TestCase
     {
         $queryParams = [];
         $request = new ProductProjectionSearchRequest();
-        $this->fixture->build($request, $queryParams);
+
+        $context = new SearchContext();
+        $context->setLanguage('en');
+        $this->fixture->build($request, $context, $queryParams);
+
 
         $result = \GuzzleHttp\Psr7\parse_query((string)$request->httpRequest()->getBody());
 
@@ -88,7 +93,7 @@ class FacetBuilderTest extends TestCase
             $result['facet']
         );
 
-        static::assertContains('variants.attributes.foobar as foobar', $result['facet']);
+        static::assertContains('variants.attributes.foobar.en as foobar', $result['facet']);
 
         static::assertContains('price:range(0 to *)', $result['filter.facets']);
         static::assertContains('price:range(0 to *)', $result['filter']);
@@ -113,18 +118,18 @@ class FacetBuilderTest extends TestCase
             ]
         ];
 
-        $this->fixture->build($request, $selectedValues);
+        $context = new SearchContext();
+        $context->setLanguage('en');
+        $this->fixture->build($request, $context, $selectedValues);
 
         $result = \GuzzleHttp\Psr7\parse_query((string)$request->httpRequest()->getBody());
-
-        static::assertContains('variants.attributes.attribute_manufacturer_name:"Apple"', $result['facet']);
 
         static::assertContains(
             'variants.attributes.attribute_manufacturer_name as attribute_manufacturer_name',
             $result['facet']
         );
 
-        static::assertContains('variants.attributes.foobar as foobar', $result['facet']);
+        static::assertContains('variants.attributes.foobar.en as foobar', $result['facet']);
 
         static::assertContains('price:range(1800 to 259900)', $result['filter']);
         static::assertContains('variants.attributes.attribute_manufacturer_name:"Apple"', $result['filter']);

--- a/src/FilterBundle/Tests/Unit/Builder/RequestBuilderTest.php
+++ b/src/FilterBundle/Tests/Unit/Builder/RequestBuilderTest.php
@@ -146,6 +146,7 @@ class RequestBuilderTest extends TestCase
                         'foobar' => 'bestit'
                     ]
                 ],
+                'language' => 'en'
             ]
         );
 
@@ -176,7 +177,8 @@ class RequestBuilderTest extends TestCase
 
         $builder = new FacetBuilder($this->facetConfigCollection);
         $resolvedValues = $builder->resolve($context->getQuery()['filter']);
-        $request = $builder->build($request, $resolvedValues);
+
+        $request = $builder->build($request, $context, $resolvedValues);
 
         $this->eventDispatcher
             ->expects(static::once())
@@ -216,6 +218,7 @@ class RequestBuilderTest extends TestCase
                         'foobar' => 'bestit'
                     ]
                 ],
+                'language' => 'en'
             ]
         );
 
@@ -245,7 +248,8 @@ class RequestBuilderTest extends TestCase
 
         $builder = new FacetBuilder($this->facetConfigCollection);
         $resolvedValues = $builder->resolve($context->getQuery()['filter']);
-        $request = $builder->build($request, $resolvedValues);
+
+        $request = $builder->build($request, $context, $resolvedValues);
 
         $this->eventDispatcher
             ->expects(static::once())

--- a/src/FilterBundle/Tests/Unit/Enum/FacetTypeTest.php
+++ b/src/FilterBundle/Tests/Unit/Enum/FacetTypeTest.php
@@ -55,8 +55,9 @@ class FacetTypeTest extends TestCase
      */
     public function testLocalizedTextValue()
     {
-        static::assertEquals('localized_text', FacetType::LOCALIZED_TEXT);
-        static::assertTrue(FacetType::isValid('localized_text'));
+        static::assertEquals('ltext', FacetType::LOCALIZED_TEXT);
+        static::assertTrue(FacetType::isValid('ltext'));
+        static::assertFalse(FacetType::isValid('localized_text'));
     }
 
     /**

--- a/src/FilterBundle/Tests/Unit/Factory/ContextFactoryTest.php
+++ b/src/FilterBundle/Tests/Unit/Factory/ContextFactoryTest.php
@@ -101,11 +101,12 @@ class ContextFactoryTest extends TestCase
                 'route' => $category,
                 'baseUrl' => 'foo-route',
                 'sorting' => 'name_asc',
-                'category' => $category
+                'category' => $category,
+                'language' => 'en'
             ]
         );
 
-        static::assertEquals($context, $this->fixture->createFromCategory($request, $category));
+        static::assertEquals($context, $this->fixture->createFromCategory($request, $category, 'en'));
     }
 
     /**
@@ -143,11 +144,12 @@ class ContextFactoryTest extends TestCase
                 'route' => $category,
                 'baseUrl' => 'foo-route',
                 'sorting' => 'name_asc',
-                'category' => $category
+                'category' => $category,
+                'language' => 'es'
             ]
         );
 
-        static::assertEquals($context, $this->fixture->createFromCategory($request, $category));
+        static::assertEquals($context, $this->fixture->createFromCategory($request, $category, 'es'));
     }
 
     /**
@@ -175,11 +177,12 @@ class ContextFactoryTest extends TestCase
                 'route' => 'search_index',
                 'baseUrl' => 'foo-route',
                 'sorting' => 'name_asc',
-                'search' => $search
+                'search' => $search,
+                'language' => 'de'
             ]
         );
 
-        static::assertEquals($context, $this->fixture->createFromSearch($request, $search));
+        static::assertEquals($context, $this->fixture->createFromSearch($request, 'de', $search));
     }
 
     /**
@@ -217,11 +220,12 @@ class ContextFactoryTest extends TestCase
                 'route' => 'search_index',
                 'baseUrl' => 'foo-route',
                 'sorting' => 'name_asc',
-                'search' => $search
+                'search' => $search,
+                'language' => 'es'
             ]
         );
 
-        static::assertEquals($context, $this->fixture->createFromSearch($request, $search));
+        static::assertEquals($context, $this->fixture->createFromSearch($request, 'es', $search));
     }
 
     /**
@@ -259,10 +263,11 @@ class ContextFactoryTest extends TestCase
                 'route' => 'search_index',
                 'baseUrl' => 'foo-route',
                 'sorting' => 'name_asc',
-                'search' => null
+                'search' => null,
+                'language' => 'fr'
             ]
         );
 
-        static::assertEquals($context, $this->fixture->createFromSearch($request, $search));
+        static::assertEquals($context, $this->fixture->createFromSearch($request, 'fr', $search));
     }
 }

--- a/src/FilterBundle/Tests/Unit/Manager/FilterManagerTest.php
+++ b/src/FilterBundle/Tests/Unit/Manager/FilterManagerTest.php
@@ -142,7 +142,7 @@ class FilterManagerTest extends TestCase
         $this->contextFactory
             ->expects(self::once())
             ->method('createFromSearch')
-            ->with(self::equalTo($request), self::equalTo($search))
+            ->with($request, 'fr', $search)
             ->willReturn(
                 $context = new SearchContext(
                     [
@@ -151,7 +151,8 @@ class FilterManagerTest extends TestCase
                             [
                                 'itemsPerPage' => 20
                             ]
-                        )
+                        ),
+                        'language' => 'fr'
                     ]
                 )
             );
@@ -174,7 +175,7 @@ class FilterManagerTest extends TestCase
             ->with(self::equalTo($context), self::equalTo($rawResponse))
             ->willReturn($response = new SearchResult());
 
-        $result = $this->fixture->search($request, $search);
+        $result = $this->fixture->search($request, $search, 'fr');
         static::assertInstanceOf(SearchResult::class, $result);
         static::assertEquals($sortingCollection, $result->getSorting());
     }

--- a/src/FilterBundle/Tests/Unit/Manager/SuggestManagerTest.php
+++ b/src/FilterBundle/Tests/Unit/Manager/SuggestManagerTest.php
@@ -99,7 +99,6 @@ class SuggestManagerTest extends TestCase
         $max = 10;
 
         $request = ProductsSuggestRequest::ofKeywords(LocalizedString::ofLangAndText('de', $keyword));
-        $request->addKeyword('en', $keyword);
         $request->fuzzy(true);
         $request->limit($max);
 
@@ -136,14 +135,6 @@ class SuggestManagerTest extends TestCase
 
         $this->client
             ->expects(static::once())
-            ->method('getConfig')
-            ->willReturn($clientConfig = new Config());
-
-        $clientConfig->setContext($context = new Context());
-        $context->setLanguages(['de', 'en']);
-
-        $this->client
-            ->expects(static::once())
             ->method('execute')
             ->with(static::equalTo($request))
             ->willReturn($response);
@@ -165,11 +156,6 @@ class SuggestManagerTest extends TestCase
     public function testGetKeywordsThrowException()
     {
         $this->expectException(ApiException::class);
-
-        $this->client
-            ->expects(static::once())
-            ->method('getConfig')
-            ->willReturn($clientConfig = new Config());
 
         $this->client
             ->expects(static::once())
@@ -206,7 +192,6 @@ class SuggestManagerTest extends TestCase
 
         $request = ProductProjectionSearchRequest::of();
         $request->addParam('text.de', $keyword);
-        $request->addParam('text.en', $keyword);
         $request->fuzzy(4);
         $request->limit($max);
         $request->markMatchingVariants(true);
@@ -245,14 +230,6 @@ class SuggestManagerTest extends TestCase
 
         $this->client
             ->expects(static::once())
-            ->method('getConfig')
-            ->willReturn($clientConfig = new Config());
-
-        $clientConfig->setContext($context = new Context());
-        $context->setLanguages(['de', 'en']);
-
-        $this->client
-            ->expects(static::once())
             ->method('execute')
             ->with(static::equalTo($request))
             ->willReturn($response);
@@ -271,14 +248,6 @@ class SuggestManagerTest extends TestCase
     public function testGetProductsThrowException()
     {
         $this->expectException(ApiException::class);
-
-        $this->client
-            ->expects(static::once())
-            ->method('getConfig')
-            ->willReturn($clientConfig = new Config());
-
-        $clientConfig->setContext($context = new Context());
-        $context->setLanguages(['de', 'en']);
 
         $this->client
             ->expects(static::once())

--- a/src/FilterBundle/Tests/Unit/Model/Facet/FacetCollectionTest.php
+++ b/src/FilterBundle/Tests/Unit/Model/Facet/FacetCollectionTest.php
@@ -75,8 +75,8 @@ class FacetCollectionTest extends TestCase
      */
     public function testSortedFacets()
     {
-        $this->fixture->addFacet((new Facet)->setConfig((new FacetConfig())->setWeight(20))->setName('Last'));
-        $this->fixture->addFacet((new Facet)->setConfig((new FacetConfig())->setWeight(3))->setName('First'));
+        $this->fixture->addFacet((new Facet)->setConfig((new FacetConfig())->setWeight(20))->setName('First'));
+        $this->fixture->addFacet((new Facet)->setConfig((new FacetConfig())->setWeight(3))->setName('Last'));
         $this->fixture->addFacet((new Facet)->setConfig((new FacetConfig())->setWeight(15))->setName('Middle'));
 
         self::assertEquals(3, count($this->fixture->getFacets()));

--- a/src/FilterBundle/Tests/Unit/Model/Facet/FacetConfigTest.php
+++ b/src/FilterBundle/Tests/Unit/Model/Facet/FacetConfigTest.php
@@ -46,7 +46,7 @@ class FacetConfigTest extends TestCase
             FacetType::CATEGORY => 'categories.id',
             FacetType::ENUM => 'variants.attributes.foo.key',
             FacetType::LENUM => 'variants.attributes.foo.key',
-            FacetType::LOCALIZED_TEXT => 'variants.attributes.de.foo'
+            FacetType::LOCALIZED_TEXT => 'variants.attributes.foo.es'
         ];
 
         foreach ($map as $type => $query) {
@@ -54,7 +54,7 @@ class FacetConfigTest extends TestCase
             $fixture->setField('foo');
             $fixture->setType($type);
 
-            static::assertEquals($query, $fixture->getFacetField());
+            static::assertEquals($query, $fixture->getFacetField('es'));
         }
     }
 
@@ -66,7 +66,7 @@ class FacetConfigTest extends TestCase
     public function testGetFacetFieldFallbackThrowException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->fixture->getFacetField();
+        $this->fixture->getFacetField('es');
     }
 
     /**
@@ -82,7 +82,7 @@ class FacetConfigTest extends TestCase
             FacetType::CATEGORY => 'categories.id',
             FacetType::ENUM => 'variants.attributes.foo.key',
             FacetType::LENUM => 'variants.attributes.foo.key',
-            FacetType::LOCALIZED_TEXT => 'variants.attributes.de.foo'
+            FacetType::LOCALIZED_TEXT => 'variants.attributes.foo.gb'
         ];
 
         foreach ($map as $type => $query) {
@@ -90,7 +90,7 @@ class FacetConfigTest extends TestCase
             $fixture->setField('foo');
             $fixture->setType($type);
 
-            static::assertEquals($query, $fixture->getFilterField());
+            static::assertEquals($query, $fixture->getFilterField('gb'));
         }
     }
 
@@ -117,7 +117,7 @@ class FacetConfigTest extends TestCase
         $value = 'name';
 
         self::assertEquals($this->fixture, $this->fixture->setFacetField($value));
-        self::assertEquals($value, $this->fixture->getFacetField());
+        self::assertEquals($value, $this->fixture->getFacetField('gb'));
     }
 
     /**
@@ -143,7 +143,7 @@ class FacetConfigTest extends TestCase
         $value = 'name';
 
         self::assertEquals($this->fixture, $this->fixture->setFilterField($value));
-        self::assertEquals($value, $this->fixture->getFilterField());
+        self::assertEquals($value, $this->fixture->getFilterField('es'));
     }
 
     /**


### PR DESCRIPTION
Dieser Fix sorgt dafür, dass Felder vom Typ `ltext` korrekt verarbeitet werden. Das ist nur ein Einzeiler. Neben den Definitionsfehler war das Feld leider auch nicht lokalisiert - 'de' war fest eingetragen.

Daher auch die Lokalisierung nochmal vorgenommen. Aktuell wird diese aus den Languages vom CT Client gezogen. War ein Pragmatischer Ansatz - jetzt wird das allerdings immer schwieriger, vor allem auch weil der CT Client mehrere Lokalisierungen gleichzeitig zulässt. Daher nun die Lokalisierung fest definiert und ins Kontext Objekt implementiert. Somit wird nun die Sprache bei den öffentlichen Methoden definiert (optional - wenn keine Lokalisierung angegeben wird, wird 'de' verwendet).

Habe versucht ein BC zu vermeiden - aber da sich das Lokalisierungshandling ändert ist es de facto dennoch ein BC ...
