### PR TITLE
Add search keyword for products request events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Added
 - Add SetType handling for EnumAttributeNormalizer @chowanski
+- Add search keyword for products request events @chowanski
 
 ## [7.0.0] - 2017-10-06
 ### Added

--- a/src/FilterBundle/Builder/RequestBuilder.php
+++ b/src/FilterBundle/Builder/RequestBuilder.php
@@ -113,7 +113,7 @@ class RequestBuilder
         $resolvedValues = $builder->resolve($this->decode($context->getQuery()));
         $request = $builder->build($request, $context, $resolvedValues);
 
-        $event = new ProductProjectionSearchRequestEvent($request);
+        $event = new ProductProjectionSearchRequestEvent($request, $context->getSearch());
         $this->eventDispatcher->dispatch(FilterEvent::PRODUCTS_REQUEST_POST, $event);
 
         /**

--- a/src/FilterBundle/Event/Request/ProductProjectionSearchRequestEvent.php
+++ b/src/FilterBundle/Event/Request/ProductProjectionSearchRequestEvent.php
@@ -22,13 +22,32 @@ class ProductProjectionSearchRequestEvent extends Event
     private $request;
 
     /**
+     * The optional search keywords
+     *
+     * @var null|string
+     */
+    private $searchKeyword;
+
+    /**
      * ProductProjectionSearchRequestEvent constructor.
      *
      * @param ProductProjectionSearchRequest $request
+     * @param string|null $searchKeyword
      */
-    public function __construct(ProductProjectionSearchRequest $request)
+    public function __construct(ProductProjectionSearchRequest $request, string $searchKeyword = null)
     {
-        $this->setRequest($request);
+        $this->request = $request;
+        $this->searchKeyword = $searchKeyword;
+    }
+
+    /**
+     * Get searchKeyword
+     *
+     * @return null|string
+     */
+    public function getSearchKeyword()
+    {
+        return $this->searchKeyword;
     }
 
     /**

--- a/src/FilterBundle/Manager/SuggestManager.php
+++ b/src/FilterBundle/Manager/SuggestManager.php
@@ -142,7 +142,7 @@ class SuggestManager implements SuggestManagerInterface
         // Match variants
         $request->markMatchingVariants($this->config->isMatchVariants());
 
-        $event = new ProductProjectionSearchRequestEvent($request);
+        $event = new ProductProjectionSearchRequestEvent($request, $keyword);
         $this->eventDispatcher->dispatch(SuggestEvent::PRODUCTS_REQUEST_POST, $event);
 
         $response = $this->client->execute($event->getRequest());

--- a/src/FilterBundle/Tests/Unit/Event/Request/ProductProjectionSearchRequestEventTest.php
+++ b/src/FilterBundle/Tests/Unit/Event/Request/ProductProjectionSearchRequestEventTest.php
@@ -25,9 +25,10 @@ class ProductProjectionSearchRequestEventTest extends TestCase
      */
     public function testSetAndGetRequest()
     {
-        $event = new ProductProjectionSearchRequestEvent($request = new ProductProjectionSearchRequest());
+        $event = new ProductProjectionSearchRequestEvent($request = new ProductProjectionSearchRequest(), 'Foobar');
 
         static::assertSame($request, $event->getRequest());
+        static::assertSame('Foobar', $event->getSearchKeyword());
 
         $newRequest = new ProductProjectionSearchRequest();
         static::assertNotSame($newRequest, $event->getRequest());


### PR DESCRIPTION
Notwendig, da ich das Suchwort aus der Request selber leider nicht mehr herausbekomme (fehlender Getter), aber für meinen Listener benötige.